### PR TITLE
Fix/moodle 310 coursecat

### DIFF
--- a/externallib.php
+++ b/externallib.php
@@ -10,7 +10,6 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 require_once($CFG->libdir . "/externallib.php");
-require_once($CFG->libdir . "/coursecatlib.php");
  
 class local_wsfunc_external extends external_api {
  
@@ -42,7 +41,7 @@ class local_wsfunc_external extends external_api {
         $options['sort']['idnumber'] = 1;
  
         
-        $courselist = coursecat::get($params['cat'])->get_courses($options);
+        $courselist = \core_course_category::get($params['cat'])->get_courses($options);
 
         //Note: don't forget to validate the context and check capabilities
         // $context = context_course::instance($course->id, IGNORE_MISSING);

--- a/version.php
+++ b/version.php
@@ -11,9 +11,9 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
-$plugin->version  = 2018041100;
+$plugin->version  = 2021051200;
 $plugin->requires = 2020110904;  // Requires this Moodle version - at least 3.10
 $plugin->cron     = 0;
 $plugin->component = 'local_wsfunc';
-$plugin->release = '0.2';
+$plugin->release = '0.2.1';
 $plugin->maturity = MATURITY_STABLE;

--- a/version.php
+++ b/version.php
@@ -12,7 +12,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 $plugin->version  = 2018041100;
-$plugin->requires = 2010112400;  // Requires this Moodle version - at least 2.0
+$plugin->requires = 2020110904;  // Requires this Moodle version - at least 3.10
 $plugin->cron     = 0;
 $plugin->component = 'local_wsfunc';
 $plugin->release = '0.2';


### PR DESCRIPTION
This should fix errors trying to set web tokens - Moodle 3.10 removed the coursecat lib and replaced with core_course_category.